### PR TITLE
tracker: session max primary alignment for verse-complete gate

### DIFF
--- a/EXPERIMENTS.md
+++ b/EXPERIMENTS.md
@@ -21,6 +21,22 @@ ONNX inference is non-deterministic at **±3–6 samples per run** on v1. Older 
 
 ### Streaming changelog
 
+**2026-04-30 — cumulative primary alignment for verse-complete** (file: `web/frontend/src/lib/tracker.ts`)
+
+The 2026-04-29 primary gate used **single-cycle** `primaryEnd` for `allowVerseComplete`. On long verses the tracking window is shorter than the verse, so the decode often shows only the **tail** while `trackingLastWordIdx` is advanced by acoustic/char fallback — `primaryEnd` in that window can stay low, which re-opened the old **0.95 cumulative-only** escape hatch and let acoustic/char-only tail progress complete the verse without enough fuzzy word matches in the **current** window.
+
+Changes: (1) remove the 0.95 cumulative-only branch entirely; (2) track `trackingPrimaryMaxIdx`, the maximum word index ever hit via **primary** alignment since `_enterTracking`, and use that for `primaryCoverage` / `primaryNearEnd` in the completion gate. Same 0.8 / last-two-words thresholds as before — evidence is now **session-accurate** under sliding windows instead of single-snapshot or acoustic-only.
+
+Re-measure before merging headline numbers:
+
+```
+cd web/frontend
+npx tsx test/stability-report.ts --repeats=2 --corpus=test_corpus_v3 --json=test/streaming-primary-max-v3-stability.json
+npx tsx test/stability-report.ts --repeats=2 --corpus=test_corpus_v2 --json=test/streaming-primary-max-v2-stability.json
+```
+
+Unit tests: `web/frontend/test/tracker-deferred.test.ts` — added `session max primary alignment + acoustic tail can complete`.
+
 **2026-04-30 — r15 utterance-level verifier restored and measured** (files: `web/frontend/test/stability-report-oracle.ts`, results `web/frontend/test/r15-verifier-v*-stability.json`)
 The tracker-only segment ownership probes were falsified: tightening pending continuation evidence and delaying non-continuation rediscovery both reduced extra cascades in some long clips but also suppressed true early anchors or let worse short-rescue anchors take over. Those attempts were reverted. The structural conclusion is that the 131 MB shipped FastConformer streaming tracker is not the right place to manufacture 90%+ v3 SeqAcc with thresholds; it needs an utterance-level verifier.
 

--- a/web/frontend/src/lib/tracker.ts
+++ b/web/frontend/src/lib/tracker.ts
@@ -275,6 +275,8 @@ export class RecitationTracker {
   private trackingVerseWords: string[] = [];
   private trackingPrefixes: TrackingPrefix[] = [];
   private trackingLastWordIdx = -1;
+  /** Max word index ever reached via primary (fuzzy word) alignment this session */
+  private trackingPrimaryMaxIdx = -1;
   private trackingProgressEstablished = false;
   private staleCycles = 0;
   private cyclesSinceCommit = Infinity;
@@ -383,6 +385,10 @@ export class RecitationTracker {
       resumeFrom,
     );
     const primaryMatchedIndices = matchedIndices.slice();
+    if (primaryMatchedIndices.length > 0) {
+      const pe = primaryMatchedIndices[primaryMatchedIndices.length - 1];
+      if (pe > this.trackingPrimaryMaxIdx) this.trackingPrimaryMaxIdx = pe;
+    }
 
     // Confirm pending emission only on primary word alignment from fresh audio
     if (
@@ -497,25 +503,21 @@ export class RecitationTracker {
 
     const cumulativeCoverage = wordPos / this.trackingVerseWords.length;
     const nearEnd = this.trackingLastWordIdx >= this.trackingVerseWords.length - 2;
-    const primaryEnd =
-      primaryMatchedIndices.length > 0
-        ? primaryMatchedIndices[primaryMatchedIndices.length - 1]
-        : -1;
+    const primaryBest = this.trackingPrimaryMaxIdx;
     const primaryCoverage =
-      this.trackingVerseWords.length > 0
-        ? (primaryEnd + 1) / this.trackingVerseWords.length
+      this.trackingVerseWords.length > 0 && primaryBest >= 0
+        ? (primaryBest + 1) / this.trackingVerseWords.length
         : 0;
-    const primaryNearEnd = primaryEnd >= this.trackingVerseWords.length - 2;
+    const primaryNearEnd = primaryBest >= this.trackingVerseWords.length - 2;
     // Auto-advance used to run when acoustic/char fallbacks pushed the word
     // index to the verse tail without primary alignment, causing false "verse
     // complete" and cascading bogus next-verse emissions on long clips.
-    // Require primary word matches for the staged completion gate; allow a
-    // narrow escape hatch only when we have reached the final word via any path.
+    // Gate on cumulative primary alignment (max over sliding-window cycles) so
+    // we still complete when the 30s window only shows the tail but earlier
+    // chunks already matched 80%+ of words — without the old 0.95
+    // cumulative-only escape hatch that acoustic/char could satisfy alone.
     const allowVerseComplete =
-      primaryCoverage >= 0.8 && primaryNearEnd
-        ? true
-        : this.trackingLastWordIdx >= this.trackingVerseWords.length - 1 &&
-          cumulativeCoverage >= 0.95;
+      primaryCoverage >= 0.8 && primaryNearEnd;
 
     if (cumulativeCoverage >= 0.8 && nearEnd && allowVerseComplete) {
       if (!(this.lastCommitEvidence?.strong)) {
@@ -1177,6 +1179,7 @@ export class RecitationTracker {
     this.trackingVerse = verse;
     this.trackingVerseWords = verse.phoneme_words;
     this.trackingLastWordIdx = -1;
+    this.trackingPrimaryMaxIdx = -1;
     this.trackingProgressEstablished = false;
     this.staleCycles = 0;
     const tokenIds = verse.phoneme_token_ids ?? [];
@@ -1206,6 +1209,7 @@ export class RecitationTracker {
     this.trackingVerseWords = [];
     this.trackingPrefixes = [];
     this.trackingLastWordIdx = -1;
+    this.trackingPrimaryMaxIdx = -1;
     this.trackingProgressEstablished = false;
     this.staleCycles = 0;
     this.lastTrackingResult = null;

--- a/web/frontend/test/tracker-deferred.test.ts
+++ b/web/frontend/test/tracker-deferred.test.ts
@@ -289,6 +289,30 @@ describe("Deferred emission", () => {
     expect(t.consecutiveAutoAdvances).toBe(0);
   });
 
+  it("session max primary alignment + acoustic tail can complete (sliding window)", async () => {
+    // Earlier cycles may have matched 80%+ of words while the current window
+    // decode has no primary hits (tail-only). Max-primary gate must still allow
+    // completion when effective progress reaches the verse end — unlike
+    // acoustic-only with primaryMax never set.
+    const transcribeFn = createTranscribeFn([makeResult(UNRELATED_TEXT)]);
+
+    const db = createMockDB();
+    const tracker = new RecitationTracker(db, transcribeFn);
+    injectTrackingState(tracker, VERSE_2);
+    const t = tracker as any;
+    t.trackingPrimaryMaxIdx = 8; // primary saw through word 8 in a prior window
+    t.trackingLastWordIdx = 7;
+    t._resolveTrackingAcousticWord = () => 9;
+
+    for (let i = 0; i < 2; i++) {
+      await tracker.feed(makeSpeechChunk());
+    }
+
+    expect(t.trackingVerse?.ayah).toBe(3);
+    expect(t.trackingPendingEmission).toBe(true);
+    expect(t.consecutiveAutoAdvances).toBe(1);
+  });
+
   it("acoustic/char-level fallback do NOT trigger pending emission", async () => {
     const transcribeFn = createTranscribeFn([
       makeResult("alif laam miim"), // VERSE_1 complete → auto-advance


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves streaming verse-complete gating for long verses under a sliding decode window.

### Problem
The prior primary-alignment gate still allowed a **0.95 cumulative coverage** path when `primaryCoverage` was low in the **current** window. Acoustic/char fallback could push `trackingLastWordIdx` to the tail without enough **fuzzy word** matches in that snapshot, matching the failure mode described in EXPERIMENTS (false verse complete → discovery cascade on long clips).

### Change
- Remove the cumulative-only escape hatch.
- Track `trackingPrimaryMaxIdx`: max word index ever reached via **primary** (`alignPosition`) alignment since `_enterTracking`.
- Use that maximum for the same **0.8 coverage + last-two-words** completion test instead of single-cycle `primaryEnd`.

This is structural (session-accurate primary evidence under sliding windows), not a new tuned threshold.

### Tests
- `npx vitest run` — all green (includes new `session max primary alignment + acoustic tail can complete` case).

### Measurement
CI workspace had a 134-byte placeholder ONNX; **v3 stability-report was not re-run here**. Please run locally and commit JSON if headline numbers move:

```bash
cd web/frontend
npx tsx test/stability-report.ts --repeats=2 --corpus=test_corpus_v3 --json=test/streaming-primary-max-v3-stability.json
npx tsx test/stability-report.ts --repeats=2 --corpus=test_corpus_v2 --json=test/streaming-primary-max-v2-stability.json
```

EXPERIMENTS.md streaming changelog documents the change and these commands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cccaeea8-ff69-4e2e-bb42-681d1360a678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cccaeea8-ff69-4e2e-bb42-681d1360a678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

